### PR TITLE
Fix hanging server

### DIFF
--- a/src/main/server_startup.c
+++ b/src/main/server_startup.c
@@ -186,13 +186,8 @@ int main(int argc, char *argv[])
     add_to_pfds(&pfds,listeningSock, &fd_count, &fd_size);
 
     while(1){
-        int polled_events = 0;
-        // polled_events = poll(pfds, fd_size, -1); // Continue checking for new events 
-        // if (polled_events < 0){
-        //     perror("poll");
-        //     exit(EXIT_FAILURE);
         do {
-            polled_events= poll(pfds, fd_count, -1); // Continue checking for new events
+            int polled_events= poll(pfds, fd_count, -1); // Continue checking for new events
         } while (polled_events == -1 && errno == EINTR);
        
         for (int i = 0; i < fd_count; i++){


### PR DESCRIPTION
Failure of Poll() would set errno = 'EINTR' causing program to stay running, but no longer working at all. Fixed temporarly by forcing failed poll() to retry.